### PR TITLE
README typo, config.js logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is a **highly costumizable** Portfolio & Blog.
 
 **Are you lost or don't know where to start? Take a look at this simple guide!**
 
-1. [Deploy](#-how-to-get-started?) your project 😎
+1. [Deploy](#-how-to-get-started) your project 😎
 
 2. [Update](#-documentation) the website to your fit 😤
 

--- a/config.js
+++ b/config.js
@@ -8,10 +8,10 @@ export default {
     ],
     // social links at the bottom of your navbar
     socials: [
-      { platform: "facebook", link: "www.facebook.com", handle: "User" },
-      { platform: "instagram", link: "https://www.instagram.com/", handle: "User" },
-      { platform: "youtube", link: "https://www.youtube.com/", handle: "@User" },
-      { platform: "github", link: "https://github.com/", handle: "@User" },
+      { platform: "fa-brands:facebook-square", link: "www.facebook.com", handle: "User" },
+      { platform: "fa-brands:instagram-square", link: "https://www.instagram.com/", handle: "User" },
+      { platform: "fa-brands:youtube-square", link: "https://www.youtube.com/", handle: "@User" },
+      { platform: "fa-brands:github-square", link: "https://github.com/", handle: "@User" },
     ],
 
     // list of yours projects

--- a/src/components/utility/SocialMedia.astro
+++ b/src/components/utility/SocialMedia.astro
@@ -24,7 +24,7 @@ const { socials, class: backgroundColor, class: flex } = Astro.props;
         <a 
           href={link}
           target="_blank">
-          <Icon pack="fa-brands" name={`${platform}-square`} width="32" height="32"/>
+          <Icon name={`${platform}`} width="32" height="32"/>
           <span data-handle>{handle}</span>
         </a>
       ))


### PR DESCRIPTION
- Fixing a typo in the README
- Change the config.js file to instead pick the full name of the Icon instead of a pre-selected brand, to ensure more freedom when selecting them.